### PR TITLE
Fix extension activation

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onCommand:yed-extension.helloWorld"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [


### PR DESCRIPTION
## Summary
- enable extension to activate when helloWorld command is executed

## Testing
- `bun run lint`
- `bun run test` *(fails: Node/Electron output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_6840185afb388326b99b226bf1210ab9